### PR TITLE
fix: upgrade GitHub workflow with new syntax

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -23,7 +23,7 @@ jobs:
               # See: https://github.com/actions/cache/blob/main/examples.md#node---yarn
             - name: Get Yarn cache directory
               id: yarn-cache-dir-path
-              run: echo "::set-output name=dir::$(yarn cache dir)"
+              run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
             - name: Use Yarn cache
               uses: actions/cache@v2
@@ -40,8 +40,8 @@ jobs:
               run: |
                   RELEASE_TRACK=canary
                   PKG_VERSION=$(npm pkg get version | sed 's/"//g')
-                  echo "::set-output name=release_track::$RELEASE_TRACK"
-                  echo "::set-output name=pkg_version::$PKG_VERSION"
+                  echo "release_track=$RELEASE_TRACK" >> $GITHUB_OUTPUT
+                  echo "pkg_version=$PKG_VERSION" >> $GITHUB_OUTPUT
 
             - name: Build package
               run: yarn build

--- a/.github/workflows/publish-dev1.yml
+++ b/.github/workflows/publish-dev1.yml
@@ -23,7 +23,7 @@ jobs:
               # See: https://github.com/actions/cache/blob/main/examples.md#node---yarn
             - name: Get Yarn cache directory
               id: yarn-cache-dir-path
-              run: echo "::set-output name=dir::$(yarn cache dir)"
+              run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
             - name: Use Yarn cache
               uses: actions/cache@v2
@@ -40,8 +40,8 @@ jobs:
               run: |
                   RELEASE_TRACK=dev1
                   PKG_VERSION=$(npm pkg get version | sed 's/"//g')
-                  echo "::set-output name=release_track::$RELEASE_TRACK"
-                  echo "::set-output name=pkg_version::$PKG_VERSION"
+                  echo "release_track=$RELEASE_TRACK" >> $GITHUB_OUTPUT
+                  echo "pkg_version=$PKG_VERSION" >> $GITHUB_OUTPUT
 
             - name: Build package
               run: yarn build

--- a/.github/workflows/publish-dev2.yml
+++ b/.github/workflows/publish-dev2.yml
@@ -23,7 +23,7 @@ jobs:
               # See: https://github.com/actions/cache/blob/main/examples.md#node---yarn
             - name: Get Yarn cache directory
               id: yarn-cache-dir-path
-              run: echo "::set-output name=dir::$(yarn cache dir)"
+              run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
             - name: Use Yarn cache
               uses: actions/cache@v2
@@ -40,8 +40,8 @@ jobs:
               run: |
                   RELEASE_TRACK=dev2
                   PKG_VERSION=$(npm pkg get version | sed 's/"//g')
-                  echo "::set-output name=release_track::$RELEASE_TRACK"
-                  echo "::set-output name=pkg_version::$PKG_VERSION"
+                  echo "release_track=$RELEASE_TRACK" >> $GITHUB_OUTPUT
+                  echo "pkg_version=$PKG_VERSION" >> $GITHUB_OUTPUT
 
             - name: Build package
               run: yarn build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
               # See: https://github.com/actions/cache/blob/main/examples.md#node---yarn
             - name: Get Yarn cache directory
               id: yarn-cache-dir-path
-              run: echo "::set-output name=dir::$(yarn cache dir)"
+              run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
             - name: Use Yarn cache
               uses: actions/cache@v2
@@ -40,8 +40,8 @@ jobs:
               run: |
                   RELEASE_TRACK=production
                   PKG_VERSION=$(npm pkg get version | sed 's/"//g')
-                  echo "::set-output name=release_track::$RELEASE_TRACK"
-                  echo "::set-output name=pkg_version::$PKG_VERSION"
+                  echo "release_track=$RELEASE_TRACK" >> $GITHUB_OUTPUT
+                  echo "pkg_version=$PKG_VERSION" >> $GITHUB_OUTPUT
 
             - name: Build package
               run: yarn build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
             - name: Get Yarn cache directory
               id: yarn-cache-dir-path
-              run: echo "::set-output name=dir::$(yarn cache dir)"
+              run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
             - name: Use Yarn cache
               uses: actions/cache@v2


### PR DESCRIPTION
because set-output has been deprecated
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204547419615988